### PR TITLE
Fix ConcurrentModificationException.

### DIFF
--- a/api/src/main/java/ru/xezard/glow/data/glow/Glow.java
+++ b/api/src/main/java/ru/xezard/glow/data/glow/Glow.java
@@ -33,6 +33,7 @@ import ru.xezard.glow.data.animation.IAnimation;
 import ru.xezard.glow.packets.WrapperPlayServerEntityMetadata;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -224,8 +225,14 @@ extends AbstractGlow
     @Override
     public void destroy()
     {
-        this.holders.forEach(this::removeHolders);
-        this.viewers.forEach(this::hideFrom);
+        for (Entity entity : new HashSet<>(this.holders))
+        {
+            this.removeHolders(entity);
+        }
+        for (Player player : new HashSet<>(this.viewers))
+        {
+            this.hideFrom(player);
+        }
 
         this.holders.clear();
         this.viewers.clear();


### PR DESCRIPTION
This PR fixes **ConcurrentModificationException** at: https://github.com/Xezard/XGlow/blob/master/api/src/main/java/ru/xezard/glow/data/glow/Glow.java#L228
Stacktrace:
```java
java.util.ConcurrentModificationException
	at java.base/java.util.HashMap$HashIterator.nextNode(HashMap.java:1493)
	at java.base/java.util.HashMap$KeyIterator.next(HashMap.java:1516)
	at java.base/java.lang.Iterable.forEach(Iterable.java:74)
	at com.nisovin.magicspells.shaded.xglow.data.glow.Glow.destroy(Glow.java:228)
	at com.nisovin.magicspells.spells.targeted.ext.GlowSpell.lambda$glow$0(GlowSpell.java:138)
	at com.nisovin.magicspells.MagicSpells.lambda$scheduleDelayedTask$4(MagicSpells.java:1421)
	at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftTask.run(CraftTask.java:99)
	at org.bukkit.craftbukkit.v1_16_R3.scheduler.CraftScheduler.mainThreadHeartbeat(CraftScheduler.java:468)
	at net.minecraft.server.v1_16_R3.MinecraftServer.b(MinecraftServer.java:1294)
	at net.minecraft.server.v1_16_R3.DedicatedServer.b(DedicatedServer.java:377)
	at net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1209)
	at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:997)
	at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:178)
	at java.base/java.lang.Thread.run(Thread.java:834)
```