### PR TITLE
[WIP] Fixed "Packet encoding of packet ID 78"

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>com.comphenix.protocol</groupId>
             <artifactId>ProtocolLib</artifactId>
-            <version>4.8.0</version>
+            <version>5.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/api/src/main/java/ru/xezard/glow/GlowAPI.java
+++ b/api/src/main/java/ru/xezard/glow/GlowAPI.java
@@ -24,6 +24,7 @@ import com.comphenix.protocol.events.ListenerPriority;
 import com.comphenix.protocol.events.PacketAdapter;
 import com.comphenix.protocol.events.PacketContainer;
 import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedWatchableObject;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.plugin.Plugin;
@@ -32,6 +33,9 @@ import ru.xezard.glow.data.glow.manager.GlowsManager;
 import ru.xezard.glow.data.glow.processor.GlowProcessor;
 import ru.xezard.glow.listeners.EntityDeathListener;
 import ru.xezard.glow.listeners.PlayerQuitListener;
+import ru.xezard.glow.packets.PacketsHelper;
+
+import java.util.List;
 
 public class GlowAPI {
     private final Plugin plugin;
@@ -66,9 +70,11 @@ public class GlowAPI {
                 Entity entity = packet.getEntityModifier(event).read(0);
 
                 GlowsManager.getInstance().getGlowByEntity(entity).ifPresent((glow) -> {
-                    packet.getWatchableCollectionModifier().write(0,
-                            GlowProcessor.getInstance().createDataWatcher(entity, glow.sees(event.getPlayer()))
-                                    .getWatchableObjects());
+                    List<WrappedWatchableObject> watchableObjects
+                            = GlowProcessor.getInstance().createDataWatcher(entity,
+                            glow.sees(event.getPlayer())).getWatchableObjects();
+                    packet.getDataValueCollectionModifier().write(0,
+                            PacketsHelper.watchableObjectsToDataValues(watchableObjects));
 
                     event.setPacket(packet);
                 });

--- a/api/src/main/java/ru/xezard/glow/data/glow/Glow.java
+++ b/api/src/main/java/ru/xezard/glow/data/glow/Glow.java
@@ -28,7 +28,7 @@ import org.bukkit.entity.Player;
 import ru.xezard.glow.data.glow.manager.GlowsManager;
 import ru.xezard.glow.data.glow.processor.GlowProcessor;
 import ru.xezard.glow.packets.AbstractPacket;
-import ru.xezard.glow.packets.AbstractWrapperPlayServerScoreboardTeam;
+import ru.xezard.glow.packets.scoreboard.AbstractWrapperPlayServerScoreboardTeam;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/api/src/main/java/ru/xezard/glow/data/glow/processor/GlowProcessor.java
+++ b/api/src/main/java/ru/xezard/glow/data/glow/processor/GlowProcessor.java
@@ -30,9 +30,9 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Entity;
 import ru.xezard.glow.data.glow.AbstractGlow;
 import ru.xezard.glow.packets.AbstractPacket;
-import ru.xezard.glow.packets.AbstractWrapperPlayServerScoreboardTeam;
-import ru.xezard.glow.packets.WrapperPlayServerEntityMetadata;
-import ru.xezard.glow.packets.WrapperPlayServerScoreboardTeam;
+import ru.xezard.glow.packets.metadata.WrapperPlayServerEntityMetadata;
+import ru.xezard.glow.packets.scoreboard.AbstractWrapperPlayServerScoreboardTeam;
+import ru.xezard.glow.packets.scoreboard.WrapperPlayServerScoreboardTeam;
 
 import java.util.List;
 import java.util.Map;
@@ -41,11 +41,12 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class GlowProcessor
-implements IGlowProcessor {
+        implements IGlowProcessor {
     static WrappedDataWatcher.Serializer BYTE_SERIALIZER =
             WrappedDataWatcher.Registry.get(Byte.class);
 
-    @NonFinal static volatile GlowProcessor instance;
+    @NonFinal
+    static volatile GlowProcessor instance;
 
     public static GlowProcessor getInstance() {
         if (instance == null) {
@@ -91,7 +92,12 @@ implements IGlowProcessor {
     public AbstractPacket createGlowPacket(Entity entity, boolean glow) {
         List<WrappedWatchableObject> metadata = this.createDataWatcher(entity, glow).getWatchableObjects();
 
-        return new WrapperPlayServerEntityMetadata(metadata, entity.getEntityId());
+        WrapperPlayServerEntityMetadata packet = new WrapperPlayServerEntityMetadata();
+
+        packet.setMetadata(metadata);
+        packet.setEntityId(entity.getEntityId());
+
+        return packet.getPacket();
     }
 
     @Override

--- a/api/src/main/java/ru/xezard/glow/data/glow/processor/IGlowProcessor.java
+++ b/api/src/main/java/ru/xezard/glow/data/glow/processor/IGlowProcessor.java
@@ -22,7 +22,7 @@ import com.comphenix.protocol.wrappers.WrappedDataWatcher;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Entity;
 import ru.xezard.glow.packets.AbstractPacket;
-import ru.xezard.glow.packets.AbstractWrapperPlayServerScoreboardTeam;
+import ru.xezard.glow.packets.scoreboard.AbstractWrapperPlayServerScoreboardTeam;
 
 import java.util.List;
 import java.util.Map;

--- a/api/src/main/java/ru/xezard/glow/packets/AbstractPacket.java
+++ b/api/src/main/java/ru/xezard/glow/packets/AbstractPacket.java
@@ -28,8 +28,6 @@ import lombok.Getter;
 import lombok.experimental.FieldDefaults;
 import org.bukkit.entity.Player;
 
-import java.lang.reflect.InvocationTargetException;
-
 @Getter
 @FieldDefaults(level = AccessLevel.PROTECTED, makeFinal = true)
 public abstract class AbstractPacket {
@@ -58,7 +56,7 @@ public abstract class AbstractPacket {
 
             try {
                 ProtocolLibrary.getProtocolManager().sendServerPacket(receiver, this.handle);
-            } catch (InvocationTargetException e) {
+            } catch (Exception e) {
                 throw new RuntimeException("Cannot send packet", e);
             }
         }

--- a/api/src/main/java/ru/xezard/glow/packets/PacketsHelper.java
+++ b/api/src/main/java/ru/xezard/glow/packets/PacketsHelper.java
@@ -1,0 +1,24 @@
+package ru.xezard.glow.packets;
+
+import com.comphenix.protocol.wrappers.WrappedDataValue;
+import com.comphenix.protocol.wrappers.WrappedDataWatcher;
+import com.comphenix.protocol.wrappers.WrappedWatchableObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PacketsHelper {
+    public static List<WrappedDataValue> watchableObjectsToDataValues(List<WrappedWatchableObject> watchableObjects) {
+        List<WrappedDataValue> wrappedDataValueList = new ArrayList<>();
+        for (WrappedWatchableObject entry : watchableObjects) {
+            if (entry == null) continue;
+            WrappedDataWatcher.WrappedDataWatcherObject obj = entry.getWatcherObject();
+            wrappedDataValueList.add(new WrappedDataValue(
+                    obj.getIndex(),
+                    obj.getSerializer(),
+                    entry.getRawValue()
+            ));
+        }
+        return wrappedDataValueList;
+    }
+}

--- a/api/src/main/java/ru/xezard/glow/packets/metadata/AbstractWrapperPlayServerEntityMetadata.java
+++ b/api/src/main/java/ru/xezard/glow/packets/metadata/AbstractWrapperPlayServerEntityMetadata.java
@@ -1,0 +1,76 @@
+/*
+ * PacketWrapper - ProtocolLib wrappers for Minecraft packets
+ * Copyright (C) dmulloy2 <http://dmulloy2.net>
+ * Copyright (C) Kristian S. Strangeland
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ru.xezard.glow.packets.metadata;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.events.PacketContainer;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedWatchableObject;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import ru.xezard.glow.packets.AbstractPacket;
+
+import java.util.List;
+
+public abstract class AbstractWrapperPlayServerEntityMetadata
+        extends AbstractPacket
+        implements IWrapperPlayServerEntityMetadata {
+    public static final PacketType TYPE = PacketType.Play.Server.ENTITY_METADATA;
+
+    protected AbstractWrapperPlayServerEntityMetadata() {
+        super(new PacketContainer(TYPE), TYPE);
+
+        this.handle.getModifier().writeDefaults();
+    }
+
+    @Override
+    public AbstractPacket getPacket() {
+        return this;
+    }
+
+    @Override
+    public int getEntityId() {
+        return this.handle.getIntegers().read(0);
+    }
+
+    @Override
+    public void setEntityId(int value) {
+        this.handle.getIntegers().write(0, value);
+    }
+
+    @Override
+    public Entity getEntity(World world) {
+        return this.handle.getEntityModifier(world).read(0);
+    }
+
+    @Override
+    public Entity getEntity(PacketEvent event) {
+        return this.getEntity(event.getPlayer().getWorld());
+    }
+
+    @Override
+    public List<WrappedWatchableObject> getMetadata() {
+        return this.handle.getWatchableCollectionModifier().read(0);
+    }
+
+    @Override
+    public void setMetadata(List<WrappedWatchableObject> value) {
+        this.handle.getWatchableCollectionModifier().write(0, value);
+    }
+}

--- a/api/src/main/java/ru/xezard/glow/packets/metadata/IWrapperPlayServerEntityMetadata.java
+++ b/api/src/main/java/ru/xezard/glow/packets/metadata/IWrapperPlayServerEntityMetadata.java
@@ -1,0 +1,43 @@
+/*
+ * PacketWrapper - ProtocolLib wrappers for Minecraft packets
+ * Copyright (C) dmulloy2 <http://dmulloy2.net>
+ * Copyright (C) Kristian S. Strangeland
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ru.xezard.glow.packets.metadata;
+
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.wrappers.WrappedWatchableObject;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import ru.xezard.glow.packets.AbstractPacket;
+
+import java.util.List;
+
+public interface IWrapperPlayServerEntityMetadata {
+    AbstractPacket getPacket();
+
+    int getEntityId();
+
+    void setEntityId(int value);
+
+    Entity getEntity(World world);
+
+    Entity getEntity(PacketEvent event);
+
+    List<WrappedWatchableObject> getMetadata();
+
+    void setMetadata(List<WrappedWatchableObject> value);
+}

--- a/api/src/main/java/ru/xezard/glow/packets/metadata/WrapperPlayServerEntityMetadata.java
+++ b/api/src/main/java/ru/xezard/glow/packets/metadata/WrapperPlayServerEntityMetadata.java
@@ -1,0 +1,95 @@
+/*
+ * PacketWrapper - ProtocolLib wrappers for Minecraft packets
+ * Copyright (C) dmulloy2 <http://dmulloy2.net>
+ * Copyright (C) Kristian S. Strangeland
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ru.xezard.glow.packets.metadata;
+
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.utility.MinecraftVersion;
+import com.comphenix.protocol.wrappers.WrappedWatchableObject;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import ru.xezard.glow.packets.AbstractPacket;
+import ru.xezard.glow.packets.metadata.versions.WrapperPlayServerEntityMetadata_v19_19;
+import ru.xezard.glow.packets.metadata.versions.WrapperPlayServerEntityMetadata_v9_18;
+
+import java.util.List;
+
+public class WrapperPlayServerEntityMetadata
+implements IWrapperPlayServerEntityMetadata {
+    IWrapperPlayServerEntityMetadata wrapper;
+
+    public WrapperPlayServerEntityMetadata() {
+        MinecraftVersion version = ProtocolLibrary.getProtocolManager().getMinecraftVersion();
+
+        switch (version.getMinor()) {
+            case 18:
+            case 17:
+            case 16:
+            case 15:
+            case 14:
+            case 13:
+            case 12:
+            case 11:
+            case 10:
+            case 9:
+                this.wrapper = new WrapperPlayServerEntityMetadata_v9_18();
+                break;
+
+            case 19:
+            default:
+                this.wrapper = new WrapperPlayServerEntityMetadata_v19_19();
+                break;
+        }
+    }
+
+    @Override
+    public AbstractPacket getPacket() {
+        return this.wrapper.getPacket();
+    }
+
+    @Override
+    public int getEntityId() {
+        return this.wrapper.getEntityId();
+    }
+
+    @Override
+    public void setEntityId(int value) {
+        this.wrapper.setEntityId(value);
+    }
+
+    @Override
+    public Entity getEntity(World world) {
+        return this.wrapper.getEntity(world);
+    }
+
+    @Override
+    public Entity getEntity(PacketEvent event) {
+        return this.wrapper.getEntity(event);
+    }
+
+    @Override
+    public List<WrappedWatchableObject> getMetadata() {
+        return this.wrapper.getMetadata();
+    }
+
+    @Override
+    public void setMetadata(List<WrappedWatchableObject> value) {
+        this.wrapper.setMetadata(value);
+    }
+}

--- a/api/src/main/java/ru/xezard/glow/packets/metadata/versions/WrapperPlayServerEntityMetadata_v19_19.java
+++ b/api/src/main/java/ru/xezard/glow/packets/metadata/versions/WrapperPlayServerEntityMetadata_v19_19.java
@@ -1,0 +1,39 @@
+/*
+ * PacketWrapper - ProtocolLib wrappers for Minecraft packets
+ * Copyright (C) dmulloy2 <http://dmulloy2.net>
+ * Copyright (C) Kristian S. Strangeland
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package ru.xezard.glow.packets.metadata.versions;
+
+import com.comphenix.protocol.wrappers.WrappedWatchableObject;
+import ru.xezard.glow.packets.PacketsHelper;
+import ru.xezard.glow.packets.metadata.AbstractWrapperPlayServerEntityMetadata;
+
+import java.util.List;
+
+public class WrapperPlayServerEntityMetadata_v19_19
+        extends AbstractWrapperPlayServerEntityMetadata {
+    @Override
+    public List<WrappedWatchableObject> getMetadata() {
+        return this.handle.getWatchableCollectionModifier().read(0);
+    }
+
+    @Override
+    public void setMetadata(List<WrappedWatchableObject> value) {
+        this.handle.getDataValueCollectionModifier().write(0,
+                PacketsHelper.watchableObjectsToDataValues(value));
+    }
+}

--- a/api/src/main/java/ru/xezard/glow/packets/metadata/versions/WrapperPlayServerEntityMetadata_v9_18.java
+++ b/api/src/main/java/ru/xezard/glow/packets/metadata/versions/WrapperPlayServerEntityMetadata_v9_18.java
@@ -16,54 +16,21 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package ru.xezard.glow.packets;
+package ru.xezard.glow.packets.metadata.versions;
 
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.events.PacketContainer;
-import com.comphenix.protocol.events.PacketEvent;
 import com.comphenix.protocol.wrappers.WrappedWatchableObject;
-import org.bukkit.World;
-import org.bukkit.entity.Entity;
+import ru.xezard.glow.packets.metadata.AbstractWrapperPlayServerEntityMetadata;
 
 import java.util.List;
 
-public class WrapperPlayServerEntityMetadata
-extends AbstractPacket {
-    public static final PacketType TYPE = PacketType.Play.Server.ENTITY_METADATA;
-
-    public WrapperPlayServerEntityMetadata() {
-        super(new PacketContainer(TYPE), TYPE);
-
-        this.handle.getModifier().writeDefaults();
-    }
-
-    public WrapperPlayServerEntityMetadata(List<WrappedWatchableObject> metadata, int entityId) {
-        this();
-
-        this.setMetadata(metadata);
-        this.setEntityId(entityId);
-    }
-
-    public int getEntityId() {
-        return this.handle.getIntegers().read(0);
-    }
-
-    public void setEntityId(int value) {
-        this.handle.getIntegers().write(0, value);
-    }
-
-    public Entity getEntity(World world) {
-        return this.handle.getEntityModifier(world).read(0);
-    }
-
-    public Entity getEntity(PacketEvent event) {
-        return this.getEntity(event.getPlayer().getWorld());
-    }
-
+public class WrapperPlayServerEntityMetadata_v9_18
+extends AbstractWrapperPlayServerEntityMetadata {
+    @Override
     public List<WrappedWatchableObject> getMetadata() {
         return this.handle.getWatchableCollectionModifier().read(0);
     }
 
+    @Override
     public void setMetadata(List<WrappedWatchableObject> value) {
         this.handle.getWatchableCollectionModifier().write(0, value);
     }

--- a/api/src/main/java/ru/xezard/glow/packets/scoreboard/AbstractWrapperPlayServerScoreboardTeam.java
+++ b/api/src/main/java/ru/xezard/glow/packets/scoreboard/AbstractWrapperPlayServerScoreboardTeam.java
@@ -16,15 +16,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package ru.xezard.glow.packets;
+package ru.xezard.glow.packets.scoreboard;
 
 import com.comphenix.protocol.PacketType;
 import com.comphenix.protocol.events.PacketContainer;
-import com.google.common.base.Preconditions;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.experimental.FieldDefaults;
+import ru.xezard.glow.packets.AbstractPacket;
 
 import java.util.Arrays;
 import java.util.Collection;

--- a/api/src/main/java/ru/xezard/glow/packets/scoreboard/IWrapperPlayServerScoreboardTeam.java
+++ b/api/src/main/java/ru/xezard/glow/packets/scoreboard/IWrapperPlayServerScoreboardTeam.java
@@ -16,10 +16,11 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package ru.xezard.glow.packets;
+package ru.xezard.glow.packets.scoreboard;
 
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import org.bukkit.ChatColor;
+import ru.xezard.glow.packets.AbstractPacket;
 
 import java.util.List;
 import java.util.Optional;

--- a/api/src/main/java/ru/xezard/glow/packets/scoreboard/WrapperPlayServerScoreboardTeam.java
+++ b/api/src/main/java/ru/xezard/glow/packets/scoreboard/WrapperPlayServerScoreboardTeam.java
@@ -16,7 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package ru.xezard.glow.packets;
+package ru.xezard.glow.packets.scoreboard;
 
 import com.comphenix.protocol.ProtocolLibrary;
 import com.comphenix.protocol.utility.MinecraftVersion;
@@ -24,9 +24,10 @@ import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import org.bukkit.ChatColor;
-import ru.xezard.glow.packets.versions.WrapperPlayServerScoreboardTeam_v9_12;
-import ru.xezard.glow.packets.versions.WrapperPlayServerScoreboardTeam_v13_16;
-import ru.xezard.glow.packets.versions.WrapperPlayServerScoreboardTeam_v17_19;
+import ru.xezard.glow.packets.AbstractPacket;
+import ru.xezard.glow.packets.scoreboard.versions.WrapperPlayServerScoreboardTeam_v13_16;
+import ru.xezard.glow.packets.scoreboard.versions.WrapperPlayServerScoreboardTeam_v17_19;
+import ru.xezard.glow.packets.scoreboard.versions.WrapperPlayServerScoreboardTeam_v9_12;
 
 import java.util.List;
 import java.util.Optional;

--- a/api/src/main/java/ru/xezard/glow/packets/scoreboard/versions/WrapperPlayServerScoreboardTeam_v13_16.java
+++ b/api/src/main/java/ru/xezard/glow/packets/scoreboard/versions/WrapperPlayServerScoreboardTeam_v13_16.java
@@ -16,94 +16,80 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package ru.xezard.glow.packets.versions;
+package ru.xezard.glow.packets.scoreboard.versions;
 
+import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import org.bukkit.ChatColor;
-import ru.xezard.glow.packets.AbstractWrapperPlayServerScoreboardTeam;
+import ru.xezard.glow.packets.scoreboard.AbstractWrapperPlayServerScoreboardTeam;
 
 import java.util.Optional;
 
-public class WrapperPlayServerScoreboardTeam_v9_12
+public class WrapperPlayServerScoreboardTeam_v13_16
 extends AbstractWrapperPlayServerScoreboardTeam {
     @Override
-    public Mode getMode() {
-        return Mode.values()[this.handle.getIntegers().read(1)];
-    }
-
-    @Override
-    public void setMode(Mode value) {
-        this.handle.getIntegers().write(1, value.ordinal());
-    }
-
-    @Override
     public Optional<WrappedChatComponent> getDisplayName() {
-        return Optional.of(WrappedChatComponent.fromJson(this.handle.getStrings().read(1)));
+        return Optional.ofNullable(this.handle.getChatComponents().read(0));
     }
 
     @Override
     public void setDisplayName(WrappedChatComponent value) {
-        this.handle.getStrings().write(0, value.getJson());
+        this.handle.getChatComponents().write(0, value);
     }
 
     @Override
     public Optional<WrappedChatComponent> getPrefix() {
-        return Optional.of(WrappedChatComponent.fromJson(this.handle.getStrings().read(2)));
+        return Optional.ofNullable(this.handle.getChatComponents().read(1));
     }
 
     @Override
     public void setPrefix(WrappedChatComponent value) {
-        this.handle.getStrings().write(2, value.getJson());
+        this.handle.getChatComponents().write(1, value);
     }
 
     @Override
     public Optional<WrappedChatComponent> getSuffix() {
-        return Optional.of(WrappedChatComponent.fromJson(this.handle.getStrings().read(3)));
+        return Optional.ofNullable(this.handle.getChatComponents().read(2));
     }
 
     @Override
     public void setSuffix(WrappedChatComponent value) {
-        this.handle.getStrings().write(3, value.getJson());
+        this.handle.getChatComponents().write(2, value);
     }
 
     @Override
     public NameTagVisibility getNameTagVisibility() {
-        return NameTagVisibility.getByIdentifier(this.handle.getStrings().read(4))
+        return NameTagVisibility.getByIdentifier(this.handle.getStrings().read(1).toUpperCase())
                                 .orElse(NameTagVisibility.NEVER);
     }
 
     @Override
     public void setNameTagVisibility(NameTagVisibility nameTagVisibility) {
-        this.handle.getStrings().write(4, nameTagVisibility.getIdentifier());
+        this.handle.getStrings().write(1, nameTagVisibility.getIdentifier());
     }
 
     @Override
     public Optional<ChatColor> getColor() {
-        int value = this.handle.getIntegers().read(0);
-
-        if (value == -1) {
-            return Optional.empty();
-        }
-
-        return Optional.of(ChatColor.values()[value]);
+        return Optional.of(this.handle.getEnumModifier(ChatColor.class,
+                        MinecraftReflection.getMinecraftClass("EnumChatFormat"))
+                .read(0));
     }
 
     @Override
-    public void setColor(ChatColor color) {
-        int value = color.ordinal() > 15 ? 0 : color.ordinal();
-
-        this.setPrefix(WrappedChatComponent.fromText(ChatColor.values()[value] + ""));
-        this.handle.getIntegers().write(0, value);
+    public void setColor(ChatColor value) {
+        this.handle.getEnumModifier(ChatColor.class,
+                        MinecraftReflection.getMinecraftClass("EnumChatFormat"))
+                .write(0, value);
     }
 
     @Override
     public CollisionRule getCollisionRule() {
-        return CollisionRule.getByIdentifier(this.handle.getStrings().read(5))
+        return CollisionRule.getByIdentifier(this.handle.getStrings().read(2))
                             .orElse(CollisionRule.NEVER);
     }
 
     @Override
     public void setCollisionRule(CollisionRule value) {
-        this.handle.getStrings().write(5, value.getIdentifier());
+        this.handle.getStrings().write(2, value.getIdentifier());
     }
 }

--- a/api/src/main/java/ru/xezard/glow/packets/scoreboard/versions/WrapperPlayServerScoreboardTeam_v17_19.java
+++ b/api/src/main/java/ru/xezard/glow/packets/scoreboard/versions/WrapperPlayServerScoreboardTeam_v17_19.java
@@ -16,12 +16,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package ru.xezard.glow.packets.versions;
+package ru.xezard.glow.packets.scoreboard.versions;
 
 import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import org.bukkit.ChatColor;
-import ru.xezard.glow.packets.AbstractWrapperPlayServerScoreboardTeam;
+import ru.xezard.glow.packets.scoreboard.AbstractWrapperPlayServerScoreboardTeam;
 
 import java.util.Optional;
 

--- a/api/src/main/java/ru/xezard/glow/packets/scoreboard/versions/WrapperPlayServerScoreboardTeam_v9_12.java
+++ b/api/src/main/java/ru/xezard/glow/packets/scoreboard/versions/WrapperPlayServerScoreboardTeam_v9_12.java
@@ -16,80 +16,94 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package ru.xezard.glow.packets.versions;
+package ru.xezard.glow.packets.scoreboard.versions;
 
-import com.comphenix.protocol.utility.MinecraftReflection;
 import com.comphenix.protocol.wrappers.WrappedChatComponent;
 import org.bukkit.ChatColor;
-import ru.xezard.glow.packets.AbstractWrapperPlayServerScoreboardTeam;
+import ru.xezard.glow.packets.scoreboard.AbstractWrapperPlayServerScoreboardTeam;
 
 import java.util.Optional;
 
-public class WrapperPlayServerScoreboardTeam_v13_16
+public class WrapperPlayServerScoreboardTeam_v9_12
 extends AbstractWrapperPlayServerScoreboardTeam {
     @Override
+    public Mode getMode() {
+        return Mode.values()[this.handle.getIntegers().read(1)];
+    }
+
+    @Override
+    public void setMode(Mode value) {
+        this.handle.getIntegers().write(1, value.ordinal());
+    }
+
+    @Override
     public Optional<WrappedChatComponent> getDisplayName() {
-        return Optional.ofNullable(this.handle.getChatComponents().read(0));
+        return Optional.of(WrappedChatComponent.fromJson(this.handle.getStrings().read(1)));
     }
 
     @Override
     public void setDisplayName(WrappedChatComponent value) {
-        this.handle.getChatComponents().write(0, value);
+        this.handle.getStrings().write(0, value.getJson());
     }
 
     @Override
     public Optional<WrappedChatComponent> getPrefix() {
-        return Optional.ofNullable(this.handle.getChatComponents().read(1));
+        return Optional.of(WrappedChatComponent.fromJson(this.handle.getStrings().read(2)));
     }
 
     @Override
     public void setPrefix(WrappedChatComponent value) {
-        this.handle.getChatComponents().write(1, value);
+        this.handle.getStrings().write(2, value.getJson());
     }
 
     @Override
     public Optional<WrappedChatComponent> getSuffix() {
-        return Optional.ofNullable(this.handle.getChatComponents().read(2));
+        return Optional.of(WrappedChatComponent.fromJson(this.handle.getStrings().read(3)));
     }
 
     @Override
     public void setSuffix(WrappedChatComponent value) {
-        this.handle.getChatComponents().write(2, value);
+        this.handle.getStrings().write(3, value.getJson());
     }
 
     @Override
     public NameTagVisibility getNameTagVisibility() {
-        return NameTagVisibility.getByIdentifier(this.handle.getStrings().read(1).toUpperCase())
+        return NameTagVisibility.getByIdentifier(this.handle.getStrings().read(4))
                                 .orElse(NameTagVisibility.NEVER);
     }
 
     @Override
     public void setNameTagVisibility(NameTagVisibility nameTagVisibility) {
-        this.handle.getStrings().write(1, nameTagVisibility.getIdentifier());
+        this.handle.getStrings().write(4, nameTagVisibility.getIdentifier());
     }
 
     @Override
     public Optional<ChatColor> getColor() {
-        return Optional.of(this.handle.getEnumModifier(ChatColor.class,
-                        MinecraftReflection.getMinecraftClass("EnumChatFormat"))
-                .read(0));
+        int value = this.handle.getIntegers().read(0);
+
+        if (value == -1) {
+            return Optional.empty();
+        }
+
+        return Optional.of(ChatColor.values()[value]);
     }
 
     @Override
-    public void setColor(ChatColor value) {
-        this.handle.getEnumModifier(ChatColor.class,
-                        MinecraftReflection.getMinecraftClass("EnumChatFormat"))
-                .write(0, value);
+    public void setColor(ChatColor color) {
+        int value = color.ordinal() > 15 ? 0 : color.ordinal();
+
+        this.setPrefix(WrappedChatComponent.fromText(ChatColor.values()[value] + ""));
+        this.handle.getIntegers().write(0, value);
     }
 
     @Override
     public CollisionRule getCollisionRule() {
-        return CollisionRule.getByIdentifier(this.handle.getStrings().read(2))
+        return CollisionRule.getByIdentifier(this.handle.getStrings().read(5))
                             .orElse(CollisionRule.NEVER);
     }
 
     @Override
     public void setCollisionRule(CollisionRule value) {
-        this.handle.getStrings().write(2, value.getIdentifier());
+        this.handle.getStrings().write(5, value.getIdentifier());
     }
 }


### PR DESCRIPTION
Fixed "Packet encoding of packet ID 78 threw", but is Work In Progress, so:
- Tested on 1.19.3 only
- Plugin/build version not changed
- Doesn't fixed unused WrapperPlayServerEntityMetadata.getMetadata(), just .setMetadata()
- Not sure about MC-packets packages structure

No time yet to finish and test it all